### PR TITLE
Modify dsm.sys and dsm.opt for Linux

### DIFF
--- a/unix/dsm.opt.sample
+++ b/unix/dsm.opt.sample
@@ -1,4 +1,4 @@
-* sample dsm.opt for IPnett Cloud
+* sample dsm.opt for SafeDC
 
-SERVERNAME mytsmserver
+SERVERNAME SafeDC
 DATEFORMAT 3

--- a/unix/dsm.sys.sample
+++ b/unix/dsm.sys.sample
@@ -1,19 +1,22 @@
-* sample dsm.sys for IPnett cloud
+* sample dsm.sys for SafeDC
 
-SERVERNAME tsmXX.cloud.ipnett.se
-  TCPSERVERADDRESS   tsmXX.cloud.ipnett.se
-  NODENAME           myTSMnodename
+SERVERNAME SafeDC
+  *** Copy and Paste Information from Safespring Backup Portal ***
+  
+  *** Copy and Paste Information from Safespring Backup Portal ***
+
   COMMMETHOD         V6TCPIP
 *  legacy clients may have to use TCPIP
-*  COMMMETHOD         TCPIP
-  TCPPORT            1600
+* COMMMETHOD         TCPIP
   SSL                yes
   SSLREQUIRED        yes
   PASSWORDACCESS     GENERATE
   MANAGEDSERVICES    SCHEDULE
   VIRTUALMOUNTPOINT  /dev
   SCHEDLOGRETENTION  28
+  SCHEDLOGNAME       /var/log/dsmsched.log
   ERRORLOGRETENTION  28
+  ERRORLOGNAME       /var/log/dsmerror.log
   SCHEDCMDDISABLED   yes
   SCHEDCMDEXCEPTION  "tbmr_license"
   SCHEDCMDEXCEPTION  "db_full"
@@ -27,3 +30,4 @@ SERVERNAME tsmXX.cloud.ipnett.se
   SRVPREPOSTSNAPDISABLED  yes
 
   REVOKEREMOTEACCESS Access
+  TESTFLAG disable_tls13


### PR DESCRIPTION
---
name: "Backup 2.0 Linux Fix"
about: Support the new Backup 2.0

---


## Summary

* Update to support the new backup portal for SafeDC BaaS Service
* Remove IPnett Branding

## Details

- We have now remove the old branding and support the new Backup Portal Copy and paste part.